### PR TITLE
Fix for removing item from Grid

### DIFF
--- a/src/Vuuri.vue
+++ b/src/Vuuri.vue
@@ -432,7 +432,7 @@ export default {
       return new Promise((resolve) => {
         this.muuri.hide(itemsToRemove, {
           onFinish: () => {
-            this.muuri.remove(itemsToRemove);
+            this.muuri.remove(itemsToRemove, {removeElements: true});
 
             valuesToRemove.forEach(value => {
               const index = this.copiedItems.findIndex(item => item._id === value._id);

--- a/src/Vuuri.vue
+++ b/src/Vuuri.vue
@@ -435,7 +435,7 @@ export default {
             this.muuri.remove(itemsToRemove);
 
             valuesToRemove.forEach(value => {
-              const index = this.copiedItems.findIndex(item => item.id === value.id);
+              const index = this.copiedItems.findIndex(item => item._id === value._id);
               this.copiedItems.splice(index, 1);
             });
 


### PR DESCRIPTION
When removing the (nth) item from a grid where n>1, the item is correctly updated on the screen, but the in-memory array always has it's "first" entry removed, which results in corruption. (i.e. loss of sync between the array and screen, and also causes an artefact overlay on the screen) This is a result of the filter using "id" (which resolves to 0) as opposed to "_id" which is the actual unique identifier for the item. Changing "id" to "_id" in "_remove" would appear to fix the issue for me, now seems to work fine.